### PR TITLE
fix: Ensure environment variables are always set to maintain consistent behavior

### DIFF
--- a/csgo_gc/platform_unix.cpp
+++ b/csgo_gc/platform_unix.cpp
@@ -229,7 +229,9 @@ void *SteamClientFactory(const void *pathBuffer)
 
 void EnsureEnvVarSet(const char *name, const char *value)
 {
-    setenv(name, value, 0);
+    // Always set the environment variable to ensure consistent behavior
+    // regardless of how the game was launched (directly or via Steam)
+    setenv(name, value, 1);
 }
 
 static void CopyToReadOnly(void *dest, const void *src, size_t size)

--- a/csgo_gc/platform_windows.cpp
+++ b/csgo_gc/platform_windows.cpp
@@ -77,10 +77,9 @@ void *SteamClientFactory(const void *pathBuffer)
 
 void EnsureEnvVarSet(const char *name, const char *value)
 {
-    if (!GetEnvironmentVariableA(name, nullptr, 0))
-    {
-        SetEnvironmentVariableA(name, value);
-    }
+    // Always set the environment variable to ensure consistent behavior
+    // regardless of how the game was launched (directly or via Steam)
+    SetEnvironmentVariableA(name, value);
 }
 
 static void *Q_memmem(const void *_haystack, size_t haystack_len, const void *_needle, size_t needle_len)


### PR DESCRIPTION
Resolve #58 .

I know this isn't the optimal solution, but it currently resolves the issue with the standalone CS:GO version. The solution for both AppIds is still under investigation.

The primary change is forcing the CS:GO AppId to be set to 730. This ensures that regardless of whether the standalone version is launched from the store (4465480) or directly (without an AppId), the game environment variable AppId will always be 730, thereby guaranteeing GC functions properly.

Although Steam will still show that the final version running is 730 (CS2) rather than 4465480, it is indeed possible to launch from 4465480.