### PR TITLE
solved vulkan immediate crash issue

### DIFF
--- a/launcher/launcher_unix.cpp
+++ b/launcher/launcher_unix.cpp
@@ -76,16 +76,14 @@ int main(int argc, char **argv)
 {
     // Add bin dir to LD_LIBRARY_PATH so Vulkan libraries and other dependencies can be found
     {
-        char binPath[512];
-        snprintf(binPath, sizeof(binPath), "bin/" GC_LIB_DIR);
-
+        const char *binPath = "bin/" GC_LIB_DIR;
         const char *currentPath = getenv("LD_LIBRARY_PATH");
         if (currentPath)
         {
-            char *newPath = (char *)malloc(strlen(binPath) + 1 + strlen(currentPath) + 1);
+            char *newPath = nullptr;
+            asprintf(&newPath, "%s:%s", binPath, currentPath);
             if (newPath)
             {
-                sprintf(newPath, "%s:%s", binPath, currentPath);
                 setenv("LD_LIBRARY_PATH", newPath, 1);
                 free(newPath);
             }

--- a/launcher/launcher_unix.cpp
+++ b/launcher/launcher_unix.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <stdlib.h>
 #include <dlfcn.h>
 
 #if defined(__APPLE__)
@@ -73,6 +74,28 @@ static void *LoadModuleAndFindSymbol(const char *modulePath, const char *symbol)
 
 int main(int argc, char **argv)
 {
+    // Add bin dir to LD_LIBRARY_PATH so Vulkan libraries and other dependencies can be found
+    {
+        char binPath[512];
+        snprintf(binPath, sizeof(binPath), "bin/" GC_LIB_DIR);
+
+        const char *currentPath = getenv("LD_LIBRARY_PATH");
+        if (currentPath)
+        {
+            char *newPath = (char *)malloc(strlen(binPath) + 1 + strlen(currentPath) + 1);
+            if (newPath)
+            {
+                sprintf(newPath, "%s:%s", binPath, currentPath);
+                setenv("LD_LIBRARY_PATH", newPath, 1);
+                free(newPath);
+            }
+        }
+        else
+        {
+            setenv("LD_LIBRARY_PATH", binPath, 1);
+        }
+    }
+
     const char *modulePath = "bin/" GC_LIB_DIR "/" LAUNCHER_LIB GC_LIB_SUFFIX GC_LIB_EXTENSION;
     LauncherMain_t LauncherMain = (LauncherMain_t)LoadModuleAndFindSymbol(modulePath, SYMBOL_NAME);
     if (!LauncherMain)


### PR DESCRIPTION
This pull request solves the game crashing when using `-vulkan` launch option

As it for now, I was not able to solve OpenGL crashing issue, but it's not really something that is needed, performance on vulkan much better, and the game behaves much more stable

I'm using these launch options (they allow stretched screen and uncap fps from your refresh rate): `STEAM_COMPAT_RUNTIME_SDL2=1 SDL_VIDEODRIVER=wayland %command% -limitvsconst +mat_queue_mode 2 +r_dynamic 0 -softparticlesdefaultoff +mat_disable_fancy_blending 1 -novid -console -nojoy -threads 8 +fps_max 0  -lv -steam -vulkan `