### PR TITLE
Add music kit StatTrak support

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -37,6 +37,10 @@ void ClientGC::HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t>
         HandleSOCacheRequest();
         break;
 
+    case GCEvent::LocalPlayerRoundMVP:
+        LocalPlayerRoundMVP();
+        break;
+
     default:
         assert(false);
         break;
@@ -431,7 +435,7 @@ void ClientGC::IncrementKillCountAttribute(GCMessageRead &messageRead)
         return;
     }
 
-    assert(message.event_type() == 0);
+    assert(message.event_type() == 0 || message.event_type() == 1);
 
     CMsgSOSingleObject update;
     if (m_inventory.IncrementKillCountAttribute(message.item_id(), message.amount(), update))
@@ -442,6 +446,28 @@ void ClientGC::IncrementKillCountAttribute(GCMessageRead &messageRead)
     {
         assert(false);
     }
+}
+
+void ClientGC::LocalPlayerRoundMVP()
+{
+    // Music kit StatTrak progress is not driven by the retired official GC path,
+    // so mirror the increment locally when the client observes a local round_mvp.
+    uint64_t itemId = m_inventory.EquippedMusicKitItemId(true);
+    if (!itemId)
+    {
+        Platform::Print("LocalPlayerRoundMVP: local MVP without equipped StatTrak music kit\n");
+        return;
+    }
+
+    CMsgSOSingleObject update;
+    if (!m_inventory.IncrementKillCountAttribute(itemId, 1, update))
+    {
+        Platform::Print("LocalPlayerRoundMVP: failed to increment music kit %llu\n", itemId);
+        return;
+    }
+
+    Platform::Print("LocalPlayerRoundMVP: incremented music kit %llu\n", itemId);
+    SendMessageToGame(true, k_ESOMsg_Update, update);
 }
 
 void ClientGC::ApplySticker(GCMessageRead &messageRead)

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -2,6 +2,7 @@
 #include "gc_client.h"
 #include "graffiti.h"
 #include "keyvalue.h"
+#include "networking_shared.h"
 
 ClientGC::ClientGC(uint64_t steamId)
     : m_steamId{ steamId }
@@ -9,6 +10,13 @@ ClientGC::ClientGC(uint64_t steamId)
 {
     // also called from ServerGC's constructor
     Graffiti::Initialize();
+
+    // The inventory exists before the worker thread starts, so seed the
+    // round_mvp event cache here and keep later refreshes on the worker thread.
+    if (m_inventory.EquippedMusicKitItemId(true))
+    {
+        m_cachedMusicKitMVPs.store(static_cast<int32_t>(m_inventory.EquippedMusicKitMVPCount(false)));
+    }
 
     StartThread();
 
@@ -19,6 +27,69 @@ ClientGC::~ClientGC()
 {
     StopThread();
     Platform::Print("ClientGC destroyed\n");
+}
+
+uint32_t ClientGC::LocalPlayerMusicKitMVPsForRoundMVPEvent() const
+{
+    // round_mvp is observed before the worker-thread inventory mirror applies
+    // the local increment, so expose the post-MVP value here.
+    int32_t cachedMVPs = m_cachedMusicKitMVPs.load();
+    return cachedMVPs >= 0 ? static_cast<uint32_t>(cachedMVPs + 1) : 0;
+}
+
+void ClientGC::RefreshCachedMusicKitMVPs()
+{
+    if (!m_inventory.EquippedMusicKitItemId(true))
+    {
+        m_cachedMusicKitMVPs.store(-1);
+        SendMusicKitMVPStateToGameServer();
+        return;
+    }
+
+    m_cachedMusicKitMVPs.store(static_cast<int32_t>(m_inventory.EquippedMusicKitMVPCount(false)));
+    SendMusicKitMVPStateToGameServer();
+}
+
+void ClientGC::SendMusicKitMVPStateToGameServer()
+{
+    int32_t userId = m_localUserId.load();
+    if (userId <= 0)
+    {
+        return;
+    }
+
+    GCMessageWrite messageWrite{ k_EMsgNetworkMusicKitMVPState };
+
+    int32_t cachedMVPs = m_cachedMusicKitMVPs.load();
+    uint32_t currentMVPs = cachedMVPs >= 0 ? static_cast<uint32_t>(cachedMVPs) : 0;
+    uint32_t hasEquippedStatTrakMusicKit = cachedMVPs >= 0 ? 1u : 0u;
+
+    messageWrite.WriteUint32(static_cast<uint32_t>(userId));
+    messageWrite.WriteUint32(hasEquippedStatTrakMusicKit);
+    messageWrite.WriteUint32(currentMVPs);
+
+    Platform::Print("ClientGC: syncing music kit MVP state to server: userid=%d haskit=%u mvps=%u\n",
+        userId,
+        hasEquippedStatTrakMusicKit,
+        currentMVPs);
+    PostToHost(HostEvent::NetMessage, 0, messageWrite.Data(), messageWrite.Size());
+}
+
+void ClientGC::SyncLocalPlayerMusicKitState(int userId)
+{
+    if (userId <= 0)
+    {
+        return;
+    }
+
+    int32_t previousUserId = m_localUserId.exchange(userId);
+    if (previousUserId != userId)
+    {
+        Platform::Print("ClientGC: local userid changed from %d to %d, syncing music kit state\n",
+            previousUserId,
+            userId);
+        SendMusicKitMVPStateToGameServer();
+    }
 }
 
 void ClientGC::HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t> &buffer)
@@ -39,6 +110,19 @@ void ClientGC::HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t>
 
     case GCEvent::LocalPlayerRoundMVP:
         LocalPlayerRoundMVP();
+        break;
+
+    case GCEvent::SyncLocalPlayerMusicKitState:
+        if (buffer.size() == sizeof(uint32_t))
+        {
+            uint32_t userId;
+            memcpy(&userId, buffer.data(), sizeof(userId));
+            SyncLocalPlayerMusicKitState(static_cast<int>(userId));
+        }
+        else
+        {
+            assert(false);
+        }
         break;
 
     default:
@@ -319,6 +403,8 @@ void ClientGC::AdjustItemEquippedState(GCMessageRead &messageRead)
         return;
     }
 
+    RefreshCachedMusicKitMVPs();
+
     // let the gameserver know, too
     SendMessageToGame(true, k_ESOMsg_UpdateMultiple, update);
 }
@@ -440,6 +526,7 @@ void ClientGC::IncrementKillCountAttribute(GCMessageRead &messageRead)
     CMsgSOSingleObject update;
     if (m_inventory.IncrementKillCountAttribute(message.item_id(), message.amount(), update))
     {
+        RefreshCachedMusicKitMVPs();
         SendMessageToGame(true, k_ESOMsg_Update, update);
     }
     else
@@ -466,6 +553,7 @@ void ClientGC::LocalPlayerRoundMVP()
         return;
     }
 
+    RefreshCachedMusicKitMVPs();
     Platform::Print("LocalPlayerRoundMVP: incremented music kit %llu\n", itemId);
     SendMessageToGame(true, k_ESOMsg_Update, update);
 }

--- a/csgo_gc/gc_client.h
+++ b/csgo_gc/gc_client.h
@@ -9,6 +9,7 @@ class ClientGC final : public SharedGC
 public:
     ClientGC(uint64_t steamId);
     ~ClientGC();
+    uint32_t LocalPlayerMusicKitMVPsForRoundMVPEvent() const;
 
 private:
     void HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t> &buffer) override;
@@ -17,6 +18,9 @@ private:
     void HandleMessage(uint32_t type, const void *data, uint32_t size);
     void HandleNetMessage(const void *data, uint32_t size);
     void HandleSOCacheRequest();
+    void RefreshCachedMusicKitMVPs();
+    void SyncLocalPlayerMusicKitState(int userId);
+    void SendMusicKitMVPStateToGameServer();
 
     // send to the local game and the game server we're connected to (if we're connected)
     void SendMessageToGame(bool sendToGameServer, uint32_t type,
@@ -52,6 +56,8 @@ private:
     const uint64_t m_steamId;
 
     Inventory m_inventory;
+    std::atomic<int32_t> m_localUserId{};
+    std::atomic<int32_t> m_cachedMusicKitMVPs{ -1 };
 
     // microtransactions, we only have one going at a time
     uint64_t m_transactionId{};

--- a/csgo_gc/gc_client.h
+++ b/csgo_gc/gc_client.h
@@ -29,6 +29,8 @@ private:
     void ClientRequestJoinServerData(GCMessageRead &messageRead);
     void SetItemPositions(GCMessageRead &messageRead);
     void IncrementKillCountAttribute(GCMessageRead &messageRead);
+    // Increment the equipped StatTrak music kit when the local player receives round MVP.
+    void LocalPlayerRoundMVP();
     void ApplySticker(GCMessageRead &messageRead);
     void StoreGetUserData(GCMessageRead &messageRead);
     void StorePurchaseInit(GCMessageRead &messageRead);

--- a/csgo_gc/gc_server.cpp
+++ b/csgo_gc/gc_server.cpp
@@ -3,6 +3,7 @@
 #include "gc_const.h"
 #include "gc_const_csgo.h"
 #include "graffiti.h"
+#include "networking_shared.h"
 
 // yuck!! needed for CSteamID (construct full id from account id)
 #include "steam/steamclientpublic.h"
@@ -21,6 +22,20 @@ ServerGC::~ServerGC()
 {
     StopThread();
     Platform::Print("ServerGC destroyed\n");
+}
+
+bool ServerGC::RoundMVPMusicKitCountForUserId(int userId, int &musickitmvps) const
+{
+    std::lock_guard<std::mutex> lock{ m_musicKitMVPStateMutex };
+
+    auto it = m_musicKitMVPStateByUserId.find(userId);
+    if (it == m_musicKitMVPStateByUserId.end() || !it->second.hasEquippedStatTrakMusicKit)
+    {
+        return false;
+    }
+
+    musickitmvps = static_cast<int>(it->second.currentMVPs + 1);
+    return true;
 }
 
 void ServerGC::HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t> &buffer)
@@ -81,6 +96,16 @@ void ServerGC::HandleMessage(uint32_t type, const void *data, uint32_t size)
 void ServerGC::HandleClientSOCacheUnsubscribe(uint64_t steamId)
 {
     Platform::Print("HandleClientSOCacheUnsubscribe: %llu\n", steamId);
+
+    {
+        std::lock_guard<std::mutex> lock{ m_musicKitMVPStateMutex };
+        auto stateIt = m_musicKitMVPStateBySteamId.find(steamId);
+        if (stateIt != m_musicKitMVPStateBySteamId.end())
+        {
+            m_musicKitMVPStateByUserId.erase(stateIt->second.userId);
+            m_musicKitMVPStateBySteamId.erase(stateIt);
+        }
+    }
 
     CMsgSOCacheUnsubscribed message;
     message.mutable_owner_soid()->set_type(SoIdTypeSteamId);
@@ -195,7 +220,12 @@ void ServerGC::HandleNetMessage(uint64_t steamId, const void *data, uint32_t siz
 
     if (!validate.IsProtobuf())
     {
-        // all the allowed messages are protobuf based
+        if (validate.TypeUnmasked() == k_EMsgNetworkMusicKitMVPState)
+        {
+            UpdateMusicKitMVPState(steamId, validate);
+            return;
+        }
+
         Platform::Print("ServerGC: ignoring non protobuf message %u from %llu\n",
             validate.TypeUnmasked(), steamId);
         return;
@@ -250,6 +280,42 @@ void ServerGC::HandleNetMessage(uint64_t steamId, const void *data, uint32_t siz
         // otherwise the old message was fine
         PostToHost(HostEvent::Message, validate.TypeMasked(), data, size);
     }
+}
+
+void ServerGC::UpdateMusicKitMVPState(uint64_t steamId, GCMessageRead &messageRead)
+{
+    uint32_t userId = messageRead.ReadUint32();
+    uint32_t hasEquippedStatTrakMusicKit = messageRead.ReadUint32();
+    uint32_t currentMVPs = messageRead.ReadUint32();
+    if (!messageRead.IsValid() || !userId || hasEquippedStatTrakMusicKit > 1)
+    {
+        Platform::Print("ServerGC: ignoring malformed music kit MVP state from %llu\n", steamId);
+        return;
+    }
+
+    MusicKitMVPState state;
+    state.userId = static_cast<int>(userId);
+    state.currentMVPs = currentMVPs;
+    state.hasEquippedStatTrakMusicKit = hasEquippedStatTrakMusicKit != 0;
+
+    {
+        std::lock_guard<std::mutex> lock{ m_musicKitMVPStateMutex };
+
+        auto &slot = m_musicKitMVPStateBySteamId[steamId];
+        if (slot.userId > 0 && slot.userId != state.userId)
+        {
+            m_musicKitMVPStateByUserId.erase(slot.userId);
+        }
+
+        slot = state;
+        m_musicKitMVPStateByUserId[state.userId] = state;
+    }
+
+    Platform::Print("ServerGC: updated music kit MVP state from %llu: userid=%u haskit=%u mvps=%u\n",
+        steamId,
+        userId,
+        hasEquippedStatTrakMusicKit,
+        currentMVPs);
 }
 
 void ServerGC::SendServerWelcome()

--- a/csgo_gc/gc_server.h
+++ b/csgo_gc/gc_server.h
@@ -7,6 +7,7 @@ class ServerGC final : public SharedGC
 public:
     ServerGC();
     ~ServerGC();
+    bool RoundMVPMusicKitCountForUserId(int userId, int &musickitmvps) const;
 
 private:
     void HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t> &buffer) override;
@@ -18,6 +19,18 @@ private:
 
     void SendServerWelcome();
     void IncrementKillCountAttribute(GCMessageRead &messageRead);
+    void UpdateMusicKitMVPState(uint64_t steamId, GCMessageRead &messageRead);
 
     bool m_sentWelcome{};
+
+    struct MusicKitMVPState
+    {
+        int userId{};
+        uint32_t currentMVPs{};
+        bool hasEquippedStatTrakMusicKit{};
+    };
+
+    mutable std::mutex m_musicKitMVPStateMutex;
+    std::unordered_map<uint64_t, MusicKitMVPState> m_musicKitMVPStateBySteamId;
+    std::unordered_map<int, MusicKitMVPState> m_musicKitMVPStateByUserId;
 };

--- a/csgo_gc/gc_shared.h
+++ b/csgo_gc/gc_shared.h
@@ -15,6 +15,7 @@ enum class GCEvent
     NetMessage, // id contains the recipient steam id, buffer contains the payload
     SOCacheRequest, // sent to client gc when connected to a gameserver
     LocalPlayerRoundMVP, // sent to client gc when the local player earns round MVP
+    SyncLocalPlayerMusicKitState, // sent to client gc from the main thread, buffer contains the local userid
     ClientSOCacheUnsubscribe, // sent to server gc when a client disconnects, id contains the steam id
 };
 

--- a/csgo_gc/gc_shared.h
+++ b/csgo_gc/gc_shared.h
@@ -14,6 +14,7 @@ enum class GCEvent
     Message, // id contains the message type, buffer contains the payload
     NetMessage, // id contains the recipient steam id, buffer contains the payload
     SOCacheRequest, // sent to client gc when connected to a gameserver
+    LocalPlayerRoundMVP, // sent to client gc when the local player earns round MVP
     ClientSOCacheUnsubscribe, // sent to server gc when a client disconnects, id contains the steam id
 };
 

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -1046,6 +1046,32 @@ uint64_t Inventory::EquippedMusicKitItemId(bool statTrakOnly) const
     return 0;
 }
 
+uint32_t Inventory::EquippedMusicKitMVPCount(bool incrementForLocalMVP) const
+{
+    uint64_t itemId = EquippedMusicKitItemId(true);
+    if (!itemId)
+    {
+        return 0;
+    }
+
+    auto it = m_items.find(itemId);
+    if (it == m_items.end())
+    {
+        return 0;
+    }
+
+    for (const CSOEconItemAttribute &attribute : it->second.attribute())
+    {
+        if (attribute.def_index() == ItemSchema::AttributeKillEater)
+        {
+            uint32_t count = m_itemSchema.AttributeUint32(&attribute);
+            return incrementForLocalMVP ? count + 1 : count;
+        }
+    }
+
+    return 0;
+}
+
 bool Inventory::NameItem(uint64_t nameTagId,
     uint64_t itemId,
     std::string_view name,

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -986,6 +986,66 @@ bool Inventory::IncrementKillCountAttribute(uint64_t itemId, uint32_t amount, CM
     return false;
 }
 
+static bool IsEquippedMusicKitItem(const CSOEconItem &item)
+{
+    // Music kits live in the shared no-team loadout.
+    for (const CSOEconItemEquipped &equipped : item.equipped_state())
+    {
+        if (equipped.new_class() == 0
+            && equipped.new_slot() == ItemSchema::LoadoutSlotMusicKit)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+uint64_t Inventory::EquippedMusicKitItemId(bool statTrakOnly) const
+{
+    for (const auto &pair : m_items)
+    {
+        const CSOEconItem &item = pair.second;
+        if (!IsEquippedMusicKitItem(item))
+        {
+            continue;
+        }
+
+        bool hasKillEater = false;
+        bool isMusicKitScoreType = false;
+
+        for (const CSOEconItemAttribute &attribute : item.attribute())
+        {
+            if (attribute.def_index() == ItemSchema::AttributeKillEater)
+            {
+                hasKillEater = true;
+            }
+            else if (attribute.def_index() == ItemSchema::AttributeKillEaterScoreType
+                && m_itemSchema.AttributeUint32(&attribute) == 1)
+            {
+                isMusicKitScoreType = true;
+            }
+        }
+
+        if (!hasKillEater)
+        {
+            if (statTrakOnly)
+            {
+                continue;
+            }
+
+            return item.id();
+        }
+
+        if (isMusicKitScoreType)
+        {
+            return item.id();
+        }
+    }
+
+    return 0;
+}
+
 bool Inventory::NameItem(uint64_t nameTagId,
     uint64_t itemId,
     std::string_view name,

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -47,6 +47,7 @@ public:
         CMsgSOSingleObject &destroy,
         CMsgGCItemCustomizationNotification &notification);
 
+    uint64_t EquippedMusicKitItemId(bool statTrakOnly) const;
     bool IncrementKillCountAttribute(uint64_t itemId, uint32_t amount, CMsgSOSingleObject &update);
 
     bool NameItem(uint64_t nameTagId,

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -48,6 +48,7 @@ public:
         CMsgGCItemCustomizationNotification &notification);
 
     uint64_t EquippedMusicKitItemId(bool statTrakOnly) const;
+    uint32_t EquippedMusicKitMVPCount(bool incrementForLocalMVP) const;
     bool IncrementKillCountAttribute(uint64_t itemId, uint32_t amount, CMsgSOSingleObject &update);
 
     bool NameItem(uint64_t nameTagId,

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -172,6 +172,7 @@ public:
 
     enum LoadoutSlot
     {
+        LoadoutSlotMusicKit = 54,
         LoadoutSlotGraffiti = 56
     };
 

--- a/csgo_gc/networking_shared.h
+++ b/csgo_gc/networking_shared.h
@@ -11,4 +11,6 @@ enum ENetworkMsg : uint32_t
 {
     // sent by the server to client when they connect, data is the auth ticket
     k_EMsgNetworkConnect = (1u << 31) - 1,
+    // sent by the client to server to keep round_mvp musickitmvps injectable
+    k_EMsgNetworkMusicKitMVPState = (1u << 31) - 2,
 };

--- a/csgo_gc/platform.h
+++ b/csgo_gc/platform.h
@@ -21,6 +21,11 @@ bool SteamClientPath(void *buffer, size_t bufferSize);
 // and get a pointer to the factory function (exported symbol CreateInterface)
 void *SteamClientFactory(const void *pathBuffer);
 
+// get a module's factory function from an already loaded game module
+// the module name is given in a platform-agnostic format
+// (e.g. "engine" maps to engine.dll / engine_client.so / engine.dylib)
+void *ModuleFactory(std::string_view moduleName);
+
 // set an envar to the specified value even if it's already set
 void SetEnvVar(const char *name, const char *value);
 

--- a/csgo_gc/platform_unix.cpp
+++ b/csgo_gc/platform_unix.cpp
@@ -239,6 +239,43 @@ void *SteamClientFactory(const void *pathBuffer)
     return dlsym(steamclient, "CreateInterface");
 }
 
+void *ModuleFactory(std::string_view moduleName)
+{
+    ModuleInfo moduleInfo;
+
+#if defined(__APPLE__)
+    std::string primaryName;
+    primaryName.assign(moduleName);
+    primaryName.append(".dylib");
+    if (!GetModuleInfo(primaryName, moduleInfo))
+    {
+        return nullptr;
+    }
+#else
+    std::string primaryName;
+    primaryName.assign(moduleName);
+    primaryName.append("_client.so");
+
+    if (!GetModuleInfo(primaryName, moduleInfo))
+    {
+        primaryName.assign(moduleName);
+        primaryName.append(".so");
+        if (!GetModuleInfo(primaryName, moduleInfo))
+        {
+            return nullptr;
+        }
+    }
+#endif
+
+    void *module = dlopen(moduleInfo.fullPath.c_str(), RTLD_NOW);
+    if (!module)
+    {
+        return nullptr;
+    }
+
+    return dlsym(module, "CreateInterface");
+}
+
 void SetEnvVar(const char *name, const char *value)
 {
     setenv(name, value, 1);

--- a/csgo_gc/platform_windows.cpp
+++ b/csgo_gc/platform_windows.cpp
@@ -87,6 +87,21 @@ void *SteamClientFactory(const void *pathBuffer)
     return GetProcAddress(steamclient, "CreateInterface");
 }
 
+void *ModuleFactory(std::string_view moduleName)
+{
+    std::string actualModuleName;
+    actualModuleName.assign(moduleName);
+    actualModuleName.append(".dll");
+
+    HMODULE module = GetModuleHandleA(actualModuleName.c_str());
+    if (!module)
+    {
+        return nullptr;
+    }
+
+    return GetProcAddress(module, "CreateInterface");
+}
+
 void SetEnvVar(const char *name, const char *value)
 {
     SetEnvironmentVariableA(name, value);

--- a/csgo_gc/steam_hook.cpp
+++ b/csgo_gc/steam_hook.cpp
@@ -162,6 +162,13 @@ public:
     virtual bool IsEmpty(const char *keyName = nullptr) const = 0;
     virtual bool GetBool(const char *keyName = nullptr, bool defaultValue = false) const = 0;
     virtual int GetInt(const char *keyName = nullptr, int defaultValue = 0) const = 0;
+    virtual uint64_t GetUint64(const char *keyName = nullptr, uint64_t defaultValue = 0) const = 0;
+    virtual float GetFloat(const char *keyName = nullptr, float defaultValue = 0.0f) const = 0;
+    virtual const char *GetString(const char *keyName = nullptr, const char *defaultValue = "") const = 0;
+    virtual const wchar_t *GetWString(const char *keyName = nullptr, const wchar_t *defaultValue = L"") const = 0;
+    virtual const void *GetPtr(const char *keyName = nullptr) const = 0;
+    virtual void SetBool(const char *keyName, bool value) = 0;
+    virtual void SetInt(const char *keyName, int value) = 0;
 };
 
 class IGameEventListener2
@@ -211,7 +218,7 @@ static CreateInterfaceFn s_engineFactory;
 static IGameEventManager2 *s_gameEventManager;
 static IVEngineClient *s_engineClient;
 
-class RoundMVPEventListener final : public IGameEventListener2
+class ClientGameEventListener final : public IGameEventListener2
 {
 public:
     void FireGameEvent(IGameEvent *event) override
@@ -221,7 +228,30 @@ public:
             return;
         }
 
-        if (strcmp(event->GetName(), "round_mvp"))
+        const char *eventName = event->GetName();
+        if (!strcmp(eventName, "round_start"))
+        {
+            int localPlayer = s_engineClient->GetLocalPlayer();
+            if (localPlayer <= 0)
+            {
+                return;
+            }
+
+            PlayerInfo playerInfo{};
+            if (!s_engineClient->GetPlayerInfo(localPlayer, &playerInfo) || playerInfo.userId <= 0)
+            {
+                return;
+            }
+
+            Platform::Print("Listener syncing local music kit state on round_start: userid=%d\n", playerInfo.userId);
+            s_clientGC->m_gc.PostToGC(GCEvent::SyncLocalPlayerMusicKitState,
+                0,
+                &playerInfo.userId,
+                sizeof(playerInfo.userId));
+            return;
+        }
+
+        if (strcmp(eventName, "round_mvp"))
         {
             return;
         }
@@ -243,10 +273,26 @@ public:
             return;
         }
 
-        Platform::Print("Listener saw local round_mvp: userid=%d reason=%d\n",
-            playerInfo.userId,
-            event->GetInt("reason"));
+        int musickitmvps = event->GetInt("musickitmvps");
+        if (musickitmvps <= 0)
+        {
+            musickitmvps = static_cast<int>(s_clientGC->m_gc.LocalPlayerMusicKitMVPsForRoundMVPEvent());
+            if (musickitmvps > 0)
+            {
+                event->SetInt("musickitmvps", musickitmvps);
+                Platform::Print("Listener injected local musickitmvps into round_mvp: %d\n", musickitmvps);
+            }
+        }
 
+        Platform::Print("Listener saw local round_mvp: userid=%d reason=%d musickitmvps=%d\n",
+            playerInfo.userId,
+            event->GetInt("reason"),
+            musickitmvps);
+
+        s_clientGC->m_gc.PostToGC(GCEvent::SyncLocalPlayerMusicKitState,
+            0,
+            &playerInfo.userId,
+            sizeof(playerInfo.userId));
         s_clientGC->m_gc.PostToGC(GCEvent::LocalPlayerRoundMVP, 0, nullptr, 0);
     }
 
@@ -256,8 +302,45 @@ public:
     }
 };
 
-static RoundMVPEventListener s_roundMVPEventListener;
-static bool s_roundMVPListenerRegistered = false;
+class ServerRoundMVPEventListener final : public IGameEventListener2
+{
+public:
+    void FireGameEvent(IGameEvent *event) override
+    {
+        if (!event || !s_serverGC || strcmp(event->GetName(), "round_mvp"))
+        {
+            return;
+        }
+
+        int userId = event->GetInt("userid");
+        if (userId <= 0)
+        {
+            return;
+        }
+
+        int musickitmvps = 0;
+        if (!s_serverGC->m_gc.RoundMVPMusicKitCountForUserId(userId, musickitmvps))
+        {
+            return;
+        }
+
+        event->SetInt("musickitmvps", musickitmvps);
+        Platform::Print("Server listener injected musickitmvps into round_mvp: userid=%d musickitmvps=%d\n",
+            userId,
+            musickitmvps);
+    }
+
+    int GetEventDebugID() override
+    {
+        return EventDebugIdInit;
+    }
+};
+
+static ClientGameEventListener s_clientGameEventListener;
+static ServerRoundMVPEventListener s_serverRoundMVPEventListener;
+static bool s_clientRoundMVPListenerRegistered = false;
+static bool s_clientRoundStartListenerRegistered = false;
+static bool s_serverRoundMVPListenerRegistered = false;
 
 static void InitializeClientGameInterfaces()
 {
@@ -266,13 +349,7 @@ static void InitializeClientGameInterfaces()
         return;
     }
 
-    HMODULE engineModule = GetModuleHandleA("engine.dll");
-    if (!engineModule)
-    {
-        return;
-    }
-
-    s_engineFactory = reinterpret_cast<CreateInterfaceFn>(GetProcAddress(engineModule, "CreateInterface"));
+    s_engineFactory = reinterpret_cast<CreateInterfaceFn>(Platform::ModuleFactory("engine"));
     if (!s_engineFactory)
     {
         Platform::Print("engine CreateInterface not found\n");
@@ -283,29 +360,80 @@ static void InitializeClientGameInterfaces()
     s_engineClient = reinterpret_cast<IVEngineClient *>(s_engineFactory(VEngineClientVersion, nullptr));
 }
 
-static void UpdateRoundMVPListener()
+static void UpdateGameEventListeners()
 {
     InitializeClientGameInterfaces();
 
-    // Keep the listener lifecycle tied to the local ClientGC so reconnects do not
-    // leave stale listeners behind in engine.dll's event manager.
-    if (s_clientGC && s_gameEventManager && !s_roundMVPListenerRegistered)
+    if (!s_gameEventManager)
     {
-        if (s_gameEventManager->AddListener(&s_roundMVPEventListener, "round_mvp", false))
+        return;
+    }
+
+    // Keep client listener lifecycle tied to the local ClientGC so reconnects do not
+    // leave stale listeners behind in engine.dll's event manager.
+    if (s_clientGC)
+    {
+        if (!s_clientRoundMVPListenerRegistered)
         {
-            s_roundMVPListenerRegistered = true;
-            Platform::Print("Registered round_mvp listener\n");
+            if (s_gameEventManager->AddListener(&s_clientGameEventListener, "round_mvp", false))
+            {
+                s_clientRoundMVPListenerRegistered = true;
+                Platform::Print("Registered round_mvp listener\n");
+            }
+            else
+            {
+                Platform::Print("Failed to register round_mvp listener\n");
+            }
+        }
+
+        if (!s_clientRoundStartListenerRegistered)
+        {
+            if (s_gameEventManager->AddListener(&s_clientGameEventListener, "round_start", false))
+            {
+                s_clientRoundStartListenerRegistered = true;
+                Platform::Print("Registered round_start listener\n");
+            }
+            else
+            {
+                Platform::Print("Failed to register round_start listener\n");
+            }
+        }
+    }
+    else
+    {
+        if (s_clientRoundMVPListenerRegistered || s_clientRoundStartListenerRegistered)
+        {
+            s_gameEventManager->RemoveListener(&s_clientGameEventListener);
+            if (s_clientRoundMVPListenerRegistered)
+            {
+                Platform::Print("Unregistered round_mvp listener\n");
+            }
+            if (s_clientRoundStartListenerRegistered)
+            {
+                Platform::Print("Unregistered round_start listener\n");
+            }
+            s_clientRoundMVPListenerRegistered = false;
+            s_clientRoundStartListenerRegistered = false;
+        }
+    }
+
+    if (s_serverGC && !s_serverRoundMVPListenerRegistered)
+    {
+        if (s_gameEventManager->AddListener(&s_serverRoundMVPEventListener, "round_mvp", true))
+        {
+            s_serverRoundMVPListenerRegistered = true;
+            Platform::Print("Registered server-side round_mvp listener\n");
         }
         else
         {
-            Platform::Print("Failed to register round_mvp listener\n");
+            Platform::Print("Failed to register server-side round_mvp listener\n");
         }
     }
-    else if (!s_clientGC && s_gameEventManager && s_roundMVPListenerRegistered)
+    else if (!s_serverGC && s_serverRoundMVPListenerRegistered)
     {
-        s_gameEventManager->RemoveListener(&s_roundMVPEventListener);
-        s_roundMVPListenerRegistered = false;
-        Platform::Print("Unregistered round_mvp listener\n");
+        s_gameEventManager->RemoveListener(&s_serverRoundMVPEventListener);
+        s_serverRoundMVPListenerRegistered = false;
+        Platform::Print("Unregistered server-side round_mvp listener\n");
     }
 }
 
@@ -2043,7 +2171,7 @@ static void Hk_SteamAPI_RunCallbacks()
 {
     Og_SteamAPI_RunCallbacks();
 
-    UpdateRoundMVPListener();
+    UpdateGameEventListeners();
 
     if (s_clientGC)
     {
@@ -2110,6 +2238,8 @@ static void Hk_SteamAPI_RunCallbacks()
 static void Hk_SteamGameServer_RunCallbacks()
 {
     Og_SteamGameServer_RunCallbacks();
+
+    UpdateGameEventListeners();
 
     if (s_serverGC)
     {

--- a/csgo_gc/steam_hook.cpp
+++ b/csgo_gc/steam_hook.cpp
@@ -8,6 +8,13 @@
 #include "platform.h"
 #include <funchook.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#ifdef SendMessage
+#undef SendMessage
+#endif
+#endif
+
 struct SteamNetworkingIdentity;
 
 // defines STEAM_PRIVATE_API
@@ -129,6 +136,178 @@ public:
 // client connect/disconnect notifications
 static GCWrapper<ClientGC, NetworkingClient> *s_clientGC;
 static GCWrapper<ServerGC, NetworkingServer> *s_serverGC;
+
+struct PlayerInfo
+{
+    uint64_t version;
+    uint64_t xuid;
+    char name[128];
+    int userId;
+    char guid[33];
+    uint32_t friendsId;
+    char friendsName[128];
+    bool fakePlayer;
+    bool isHltv;
+    uint32_t customFiles[4];
+    unsigned char filesDownloaded;
+};
+
+class IGameEvent
+{
+public:
+    virtual ~IGameEvent() = default;
+    virtual const char *GetName() const = 0;
+    virtual bool IsReliable() const = 0;
+    virtual bool IsLocal() const = 0;
+    virtual bool IsEmpty(const char *keyName = nullptr) const = 0;
+    virtual bool GetBool(const char *keyName = nullptr, bool defaultValue = false) const = 0;
+    virtual int GetInt(const char *keyName = nullptr, int defaultValue = 0) const = 0;
+};
+
+class IGameEventListener2
+{
+public:
+    virtual ~IGameEventListener2() = default;
+    virtual void FireGameEvent(IGameEvent *event) = 0;
+    virtual int GetEventDebugID() = 0;
+};
+
+class IGameEventManager2
+{
+public:
+    virtual ~IGameEventManager2() = default;
+    virtual int LoadEventsFromFile(const char *filename) = 0;
+    virtual void Reset() = 0;
+    virtual bool AddListener(IGameEventListener2 *listener, const char *name, bool serverSide) = 0;
+    virtual bool FindListener(IGameEventListener2 *listener, const char *name) = 0;
+    virtual void RemoveListener(IGameEventListener2 *listener) = 0;
+};
+
+class IVEngineClient
+{
+public:
+    virtual void Unused0() = 0;
+    virtual void Unused1() = 0;
+    virtual void Unused2() = 0;
+    virtual void Unused3() = 0;
+    virtual void Unused4() = 0;
+    virtual void Unused5() = 0;
+    virtual void Unused6() = 0;
+    virtual void Unused7() = 0;
+    virtual bool GetPlayerInfo(int entNum, PlayerInfo *info) = 0;
+    virtual int GetPlayerForUserID(int userId) = 0;
+    virtual void *TextMessageGet(const char *name) = 0;
+    virtual bool Con_IsVisible() = 0;
+    virtual int GetLocalPlayer() = 0;
+};
+
+using CreateInterfaceFn = void *(*)(const char *name, int *returnCode);
+
+constexpr const char *GameEventManagerVersion = "GAMEEVENTSMANAGER002";
+constexpr const char *VEngineClientVersion = "VEngineClient014";
+constexpr int EventDebugIdInit = 42;
+
+static CreateInterfaceFn s_engineFactory;
+static IGameEventManager2 *s_gameEventManager;
+static IVEngineClient *s_engineClient;
+
+class RoundMVPEventListener final : public IGameEventListener2
+{
+public:
+    void FireGameEvent(IGameEvent *event) override
+    {
+        if (!event || !s_clientGC || !s_engineClient)
+        {
+            return;
+        }
+
+        if (strcmp(event->GetName(), "round_mvp"))
+        {
+            return;
+        }
+
+        int localPlayer = s_engineClient->GetLocalPlayer();
+        if (localPlayer <= 0)
+        {
+            return;
+        }
+
+        PlayerInfo playerInfo{};
+        if (!s_engineClient->GetPlayerInfo(localPlayer, &playerInfo))
+        {
+            return;
+        }
+
+        if (event->GetInt("userid") != playerInfo.userId)
+        {
+            return;
+        }
+
+        Platform::Print("Listener saw local round_mvp: userid=%d reason=%d\n",
+            playerInfo.userId,
+            event->GetInt("reason"));
+
+        s_clientGC->m_gc.PostToGC(GCEvent::LocalPlayerRoundMVP, 0, nullptr, 0);
+    }
+
+    int GetEventDebugID() override
+    {
+        return EventDebugIdInit;
+    }
+};
+
+static RoundMVPEventListener s_roundMVPEventListener;
+static bool s_roundMVPListenerRegistered = false;
+
+static void InitializeClientGameInterfaces()
+{
+    if (s_engineFactory)
+    {
+        return;
+    }
+
+    HMODULE engineModule = GetModuleHandleA("engine.dll");
+    if (!engineModule)
+    {
+        return;
+    }
+
+    s_engineFactory = reinterpret_cast<CreateInterfaceFn>(GetProcAddress(engineModule, "CreateInterface"));
+    if (!s_engineFactory)
+    {
+        Platform::Print("engine CreateInterface not found\n");
+        return;
+    }
+
+    s_gameEventManager = reinterpret_cast<IGameEventManager2 *>(s_engineFactory(GameEventManagerVersion, nullptr));
+    s_engineClient = reinterpret_cast<IVEngineClient *>(s_engineFactory(VEngineClientVersion, nullptr));
+}
+
+static void UpdateRoundMVPListener()
+{
+    InitializeClientGameInterfaces();
+
+    // Keep the listener lifecycle tied to the local ClientGC so reconnects do not
+    // leave stale listeners behind in engine.dll's event manager.
+    if (s_clientGC && s_gameEventManager && !s_roundMVPListenerRegistered)
+    {
+        if (s_gameEventManager->AddListener(&s_roundMVPEventListener, "round_mvp", false))
+        {
+            s_roundMVPListenerRegistered = true;
+            Platform::Print("Registered round_mvp listener\n");
+        }
+        else
+        {
+            Platform::Print("Failed to register round_mvp listener\n");
+        }
+    }
+    else if (!s_clientGC && s_gameEventManager && s_roundMVPListenerRegistered)
+    {
+        s_gameEventManager->RemoveListener(&s_roundMVPEventListener);
+        s_roundMVPListenerRegistered = false;
+        Platform::Print("Unregistered round_mvp listener\n");
+    }
+}
 
 template<size_t N>
 inline bool InterfaceMatches(const char *name, const char (&compare)[N])
@@ -1863,6 +2042,8 @@ static void Hk_SteamAPI_UnregisterCallback(class CCallbackBase *pCallback)
 static void Hk_SteamAPI_RunCallbacks()
 {
     Og_SteamAPI_RunCallbacks();
+
+    UpdateRoundMVPListener();
 
     if (s_clientGC)
     {


### PR DESCRIPTION
* Enable StatTrak music kit MVP counting

* Update music kit MVP tracking and logging

---

By default StatTrak music kit only works in official DS, but now it is impossible anyway. Two features have been implemented for the StatTrak music kit in this PR:

First, the client listens for the `round_mvp` event and increments the count whenever a local player is awarded MVP. 

Second, the inventory system identifies the currently equipped StatTrak music kit and increments the `kill eater` value by 1.

<img width="1160" height="972" alt="image" src="https://github.com/user-attachments/assets/4fe05013-5ec1-47e3-a9b6-4b17407806ff" />

StatTrak now counts in all matches, including bots, P2P matches and SRCDS matches, with GC patched.

<img width="1029" height="282" alt="image" src="https://github.com/user-attachments/assets/4c7ee316-86d5-4078-9ac4-3fd9b4bffa15" />

HUD display is yet to be implemented, as this is related to Panorama. I'm still investigating into this.